### PR TITLE
fix: harden boot module export and patch loader path

### DIFF
--- a/crm-app/js/boot/boot_hardener.js
+++ b/crm-app/js/boot/boot_hardener.js
@@ -1,109 +1,77 @@
 /* eslint-disable no-console */
-/**
- * boot_hardener.js
- * Deterministic boot: import CORE (ordered) then PATCHES (ordered), normalize telemetry,
- * expose __BOOT_DONE__, and schedule a double-rAF repaint.
- * Idempotent and JS-only.
- */
+// Deterministic boot hardener — top-level export, no conditional exports.
+export async function ensureCoreThenPatches(manifest = {}) {
+  // De-dup concurrent callers
+  if (window.__BOOT_HARDENER_PROMISE__) return window.__BOOT_HARDENER_PROMISE__;
+  window.__BOOT_HARDENER_PROMISE__ = (async () => {
+    // Normalize telemetry arrays; tolerate legacy {ok,fail}
+    const tl = window.__PATCHES_LOADED__;
+    const tf = window.__PATCHES_FAILED__;
+    window.__PATCHES_LOADED__ = Array.isArray(tl) ? tl.slice()
+      : (tl && typeof tl === "object" && Array.isArray(tl.ok)) ? tl.ok.slice() : [];
+    window.__PATCHES_FAILED__ = Array.isArray(tf) ? tf.slice()
+      : (tf && typeof tf === "object" && Array.isArray(tf.fail)) ? tf.fail.slice() : [];
 
-ensureHardenerGlobals();
+    const acc = { loaded: [], failed: [] };
 
-function ensureHardenerGlobals() {
-  if (!Array.isArray(window.__PATCHES_LOADED__)) window.__PATCHES_LOADED__ = [];
-  if (!Array.isArray(window.__PATCHES_FAILED__)) window.__PATCHES_FAILED__ = [];
-
-  // Some older builds used an object { ok:[], fail:[] }. Normalize once if found.
-  try {
-    const t = window.__PATCHES_LOADED__;
-    if (t && typeof t === "object" && !Array.isArray(t)) {
-      const ok = Array.isArray(t.ok) ? t.ok : [];
-      const fail = Array.isArray(t.fail) ? t.fail : [];
-      window.__PATCHES_LOADED__ = ok.slice();
-      window.__PATCHES_FAILED__ = fail.slice();
+    function corePrereqsReady() {
+      return typeof window.openDB === "function" && !!(window.Selection || window.SelectionService);
     }
-  } catch (_) {}
 
-  if (!window.__BOOT_HARDENER_RAN__) {
-    window.__BOOT_HARDENER_RAN__ = true;
-  }
+    async function importOne(path) {
+      if (!path || typeof path !== "string") return;
+      try {
+        const base = (document?.baseURI) ? document.baseURI : (window.location?.href || "/");
+        const spec = new URL(path, base).href;
+        await import(spec);
+        acc.loaded.push(spec);
+        if (!window.__PATCHES_LOADED__.includes(spec)) window.__PATCHES_LOADED__.push(spec);
+      } catch (err) {
+        acc.failed.push(path);
+        if (!window.__PATCHES_FAILED__.includes(path)) window.__PATCHES_FAILED__.push(path);
+        console.error("[boot] failed to import", path, err);
+      }
+    }
+
+    async function importSeq(list) {
+      for (const p of (list || [])) {
+        // eslint-disable-next-line no-await-in-loop
+        await importOne(p);
+      }
+    }
+
+    const CORE = Array.isArray(manifest.CORE) ? manifest.CORE : [];
+    const PATCHES = Array.isArray(manifest.PATCHES) ? manifest.PATCHES : [];
+
+    // CORE → PATCHES (strict order)
+    await importSeq(CORE);
+    if (!corePrereqsReady() && CORE.length) {
+      console.warn("[boot] core prereqs missing after pass 1; retrying CORE once");
+      await importSeq(CORE);
+    }
+    await importSeq(PATCHES);
+
+    window.__BOOT_DONE__ = {
+      loaded: Array.from(new Set(acc.loaded)),
+      failed: Array.from(new Set(acc.failed)),
+    };
+
+    // Expose diagnostics helper without side effects
+    window.__BOOT_HARDENER__ = Object.assign(window.__BOOT_HARDENER__ || {}, { corePrereqsReady });
+
+    // Double-rAF repaint
+    try {
+      const raf = window.requestAnimationFrame || (cb => setTimeout(cb, 16));
+      raf(() => raf(() => window.renderAll?.()));
+    } catch (_) {}
+
+    if (window.__BOOT_DONE__.failed.length) {
+      console.warn("[boot] completed with failures:", window.__BOOT_DONE__.failed);
+    } else {
+      console.log("[boot] ok:", window.__BOOT_DONE__.loaded.length, "fail:0");
+    }
+
+    return window.__BOOT_DONE__;
+  })();
+  return window.__BOOT_HARDENER_PROMISE__;
 }
-
-async function importOne(path, acc) {
-  if (!path || typeof path !== "string") return;
-  const url = path.startsWith("/") ? path : "/" + path.replace(/^(\.\/)+/, "");
-  try {
-    await import(url);
-    acc.loaded.push(url);
-    if (!window.__PATCHES_LOADED__.includes(url)) window.__PATCHES_LOADED__.push(url);
-  } catch (err) {
-    acc.failed.push(url);
-    if (!window.__PATCHES_FAILED__.includes(url)) window.__PATCHES_FAILED__.push(url);
-    console.error("[boot] failed to import", url, err);
-  }
-}
-
-async function importSequential(paths, acc) {
-  for (const p of paths || []) {
-    // eslint-disable-next-line no-await-in-loop
-    await importOne(p, acc);
-  }
-}
-
-function corePrereqsReady() {
-  const okOpenDB = typeof window.openDB === "function";
-  const okSelection = !!(window.Selection || window.SelectionService);
-  return okOpenDB && okSelection;
-}
-
-export async function ensureCoreThenPatches(manifest) {
-  ensureHardenerGlobals();
-
-  const CORE = manifest && Array.isArray(manifest.CORE) ? manifest.CORE.slice() : [];
-  const PATCHES = manifest && Array.isArray(manifest.PATCHES) ? manifest.PATCHES.slice() : [];
-  const acc = { loaded: [], failed: [] };
-
-  if (!Object.prototype.hasOwnProperty.call(window, "__EXPECTED_PATCHES__")) {
-    Object.defineProperty(window, "__EXPECTED_PATCHES__", {
-      value: PATCHES.slice(),
-      enumerable: false,
-      writable: false,
-      configurable: true,
-    });
-  }
-
-  // 1) Import CORE in strict order
-  await importSequential(CORE, acc);
-
-  // 2) If core prereqs are still missing, try one more pass of CORE only
-  if (!corePrereqsReady() && CORE.length) {
-    console.warn("[boot] core prereqs not ready; attempting a second CORE pass once");
-    await importSequential(CORE, acc);
-  }
-
-  // 3) Import PATCHES in strict order
-  await importSequential(PATCHES, acc);
-
-  // 4) Publish summary (de-duplicated)
-  window.__BOOT_DONE__ = {
-    loaded: Array.from(new Set(acc.loaded)),
-    failed: Array.from(new Set(acc.failed)),
-  };
-
-  // 5) Schedule a double-rAF repaint if renderAll exists
-  try {
-    const raf = window.requestAnimationFrame || ((cb) => setTimeout(cb, 16));
-    raf(() => raf(() => window.renderAll && window.renderAll()));
-  } catch (_) {}
-
-  if (window.__BOOT_DONE__.failed.length) {
-    console.warn("[boot] completed with failures:", window.__BOOT_DONE__.failed);
-  } else {
-    console.log("[boot] ok:", window.__BOOT_DONE__.loaded.length, "fail:0");
-  }
-}
-
-window.__BOOT_HARDENER__ = {
-  ensureCoreThenPatches,
-  corePrereqsReady,
-};
-

--- a/crm-app/js/patches/loader.js
+++ b/crm-app/js/patches/loader.js
@@ -1,4 +1,3 @@
-/* Patches Loader: delegate to boot loader to keep a single ordered boot path. */
-import "../boot/loader.js";
+/* Patches Loader → single ordered boot path via boot loader */
+import "/js/boot/loader.js";
 export {};
-


### PR DESCRIPTION
## Summary
- ensure the boot hardener exports `ensureCoreThenPatches` at module scope while keeping idempotent sequencing and diagnostics
- normalize patch telemetry arrays and preserve strict CORE then PATCHES ordering
- load patches through the absolute `/js/boot/loader.js` entrypoint to avoid doubled `js` segments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e42b32a8d88326b4da3fe19c09fc5f