### PR TITLE
Fix boot loader import path in patches loader

### DIFF
--- a/crm-app/js/patches/loader.js
+++ b/crm-app/js/patches/loader.js
@@ -1,3 +1,3 @@
 /* Patches Loader → single ordered boot path via boot loader */
-import "/js/boot/loader.js";
+import "../boot/loader.js";
 export {};


### PR DESCRIPTION
## Summary
- restore patches loader import to use a relative path so deployments under subdirectories can resolve the boot loader module

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4328f573483268eca8e3196fd8bd3