### PR TITLE
Fix kanban stage normalization to update legacy aliases

### DIFF
--- a/crm-app/js/pipeline/kanban_dnd.js
+++ b/crm-app/js/pipeline/kanban_dnd.js
@@ -133,7 +133,8 @@ async function persistStage(contactId, newStage){
     row = null;
   }
   if(!row) return false;
-  if(NORMALIZE_STAGE(row.stage) === st) return true;
+  const currentNormalized = NORMALIZE_STAGE(row.stage);
+  if(currentNormalized === st && row.stage === st) return true;
 
   row.stage = st;
   row.updatedAt = Date.now();


### PR DESCRIPTION
## Summary
- ensure `persistStage` only exits early when the stored stage already matches the canonical target value
- allow legacy aliases to be updated to their normalized stage name so drag-and-drop persists correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e43f2c34848326bdcce732b6141b4d