### PR TITLE
Handle canonical long-shot stage for new lead automation

### DIFF
--- a/crm-app/js/patch_2025-09-26_phase2_automations.js
+++ b/crm-app/js/patch_2025-09-26_phase2_automations.js
@@ -998,7 +998,7 @@
       if(contact.pbPostClose !== false && toStage === 'funded' && contact.fundedDate){
         await queuePostClose(contact);
       }
-      if(contact.pbNewLead !== false && (toStage === 'lead' || toStage === 'preapproved')){
+      if(contact.pbNewLead !== false && (toStage === 'long-shot' || toStage === 'lead' || toStage === 'preapproved')){
         if(!(detail && detail.isNew)) await queueNewLead(contact);
       }
       if(!skipDocSync){


### PR DESCRIPTION
## Summary
- ensure the new-lead automation fires when contacts enter the canonical long-shot stage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4573a9ec4832693d661a8ecdfdf4f