### PR TITLE
fix: delegate merge handling and add partners merge orchestration

### DIFF
--- a/crm-app/js/merge/merge_core.js
+++ b/crm-app/js/merge/merge_core.js
@@ -101,3 +101,33 @@ export function pickWinnerContact(a, b) {
   const sa = nonEmpty(a), sb = nonEmpty(b);
   return sa >= sb ? "A" : "B";
 }
+
+export function mergePartners(a, b, picks) {
+  // Similar policy to contacts; tailor fields if needed
+  const template = Object.assign({}, a, b);
+  const result = {};
+  for (const field of Object.keys(template)) {
+    if (/^id$/i.test(field) || /^createdAt$/i.test(field) || /^updatedAt$/i.test(field) || /^__/.test(field)) continue;
+    const pick = picks?.[field];
+    if (pick === "NONE") continue;
+
+    if (Array.isArray(a?.[field]) || Array.isArray(b?.[field])) {
+      if (pick === "A") result[field] = Array.isArray(a?.[field]) ? a[field] : [];
+      else if (pick === "B") result[field] = Array.isArray(b?.[field]) ? b[field] : [];
+      else result[field] = unionArray(a?.[field], b?.[field], "id");
+      continue;
+    }
+    if (pick === "A") { result[field] = a?.[field]; continue; }
+    if (pick === "B") { result[field] = b?.[field]; continue; }
+    result[field] = chooseValue(field, a, b).value;
+  }
+  result.updatedAt = Date.now();
+  return result;
+}
+
+export function pickWinnerPartner(a, b) {
+  // Prefer record with more non-empty fields; tie → A
+  const nonEmpty = (obj) => Object.keys(obj || {}).reduce((n, k) => n + (isNonEmpty(obj[k]) ? 1 : 0), 0);
+  const sa = nonEmpty(a), sb = nonEmpty(b);
+  return sa >= sb ? "A" : "B";
+}

--- a/crm-app/js/partners_merge_orchestrator.js
+++ b/crm-app/js/partners_merge_orchestrator.js
@@ -1,0 +1,131 @@
+/* eslint-disable no-console */
+import { openMergeModal } from "/js/ui/merge_modal.js";
+import { mergePartners, pickWinnerPartner } from "/js/merge/merge_core.js";
+
+// ---- Minimal DB helpers (match contacts orchestrator patterns) ----
+async function dbGetSafe(store, id) {
+  if (typeof window.dbGet === "function") return window.dbGet(store, id);
+  if (typeof window.withStore === "function" && typeof window.openDB === "function") {
+    return new Promise(async (resolve, reject) => {
+      try {
+        await window.withStore(store, "readonly", (st) => {
+          const req = st.get(id);
+          req.onsuccess = () => resolve(req.result);
+          req.onerror = (e) => reject(e);
+        });
+      } catch (e) { reject(e); }
+    });
+  }
+  throw new Error("dbGet not available");
+}
+async function dbPutSafe(store, value, key) {
+  if (typeof window.dbPut === "function") return window.dbPut(store, value, key);
+  if (typeof window.withStore === "function" && typeof window.openDB === "function") {
+    return new Promise(async (resolve, reject) => {
+      try {
+        await window.withStore(store, "readwrite", (st) => {
+          const req = key != null ? st.put(value, key) : st.put(value);
+          req.onsuccess = () => resolve(req.result);
+          req.onerror = (e) => reject(e);
+        });
+      } catch (e) { reject(e); }
+    });
+  }
+  throw new Error("dbPut not available");
+}
+async function dbDeleteSafe(store, key) {
+  if (typeof window.dbDelete === "function") return window.dbDelete(store, key);
+  if (typeof window.withStore === "function" && typeof window.openDB === "function") {
+    return new Promise(async (resolve, reject) => {
+      try {
+        await window.withStore(store, "readwrite", (st) => {
+          const req = st.delete(key);
+          req.onsuccess = () => resolve(true);
+          req.onerror = (e) => reject(e);
+        });
+      } catch (e) { reject(e); }
+    });
+  }
+  return false;
+}
+
+// Update partnerId references in any store that uses it
+async function relinkPartnerReferences(winnerId, loserId) {
+  const candidateStores = ["contacts", "deals", "opportunities", "activities", "notes", "documents"]; // will filter to real ones
+  const exists = [];
+  if (typeof window.openDB !== "function") return;
+
+  // Discover which stores actually exist
+  try {
+    await window.withStore(null, "readonly", (st) => {}); // no-op but ensures DB open
+    const db = window.__DB__ || window.__db__ || null; // if code exposes DB; otherwise we try blindly
+    // If we can’t introspect, proceed with candidateStores and catch per-store failures
+  } catch(_) {}
+
+  for (const store of candidateStores) {
+    try {
+      await window.withStore(store, "readonly", () => {});
+      exists.push(store);
+    } catch (_) { /* store not present; skip */ }
+  }
+
+  for (const store of exists) {
+    try {
+      await window.withStore(store, "readwrite", (st) => {
+        const req = st.openCursor();
+        req.onsuccess = () => {
+          const cursor = req.result;
+          if (!cursor) return;
+          const val = cursor.value || {};
+          if (val.partnerId === loserId) {
+            val.partnerId = winnerId;
+            const putReq = cursor.update(val);
+            putReq.onsuccess = () => {};
+          }
+          cursor.continue();
+        };
+      });
+    } catch (e) {
+      console.warn("[partners:relink] failed store", store, e);
+    }
+  }
+}
+
+export async function openPartnersMergeByIds(idA, idB) {
+  const [a, b] = await Promise.all([dbGetSafe("partners", idA), dbGetSafe("partners", idB)]);
+  if (!a || !b) { console.error("[merge] partners not found", { idA, idB, a: !!a, b: !!b }); return; }
+
+  openMergeModal({
+    kind: "partners",
+    recordA: a,
+    recordB: b,
+    onConfirm: async (picks) => {
+      try {
+        const winner = pickWinnerPartner(a, b); // "A" or "B"
+        const winnerRec = winner === "A" ? a : b;
+        const loserRec  = winner === "A" ? b : a;
+        const winnerId  = winnerRec.id ?? idA;
+        const loserId   = loserRec.id  ?? idB;
+
+        const merged = mergePartners(a, b, picks);
+        merged.id = winnerId;
+
+        await dbPutSafe("partners", merged, winnerId);
+        // re-link references before deleting loser
+        await relinkPartnerReferences(winnerId, loserId);
+        await dbDeleteSafe("partners", loserId);
+
+        // Clear selection and repaint once
+        try { window.Selection?.clear?.(); } catch(_) {}
+        try {
+          const evt = new CustomEvent("selection:changed", { detail: { clearedBy: "merge-partners" }});
+          window.dispatchEvent(evt);
+        } catch(_) {}
+        try { window.dispatchAppDataChanged?.("partners:merge"); } catch(_) {}
+      } catch (err) {
+        console.error("[merge] partners failed", err);
+      }
+    },
+    onCancel: () => {}
+  });
+}

--- a/crm-app/js/ui/merge_modal.js
+++ b/crm-app/js/ui/merge_modal.js
@@ -16,7 +16,7 @@ export function openMergeModal({ kind = "contacts", recordA, recordB, onConfirm,
 <div class="merge-overlay" role="dialog" aria-modal="true" style="position:fixed;inset:0;z-index:10000;background:rgba(0,0,0,0.45);display:flex;align-items:center;justify-content:center;">
   <div class="merge-modal" style="background:#fff;min-width:720px;max-width:960px;border-radius:12px;box-shadow:0 12px 40px rgba(0,0,0,0.3);">
     <div style="display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid #eee;">
-      <div style="font-size:18px;font-weight:600;">Merge ${kind === "contacts" ? "Contacts" : "Records"}</div>
+      <div style="font-size:18px;font-weight:600;">Merge ${kind === "contacts" ? "Contacts" : kind === "partners" ? "Partners" : "Records"}</div>
       <button class="merge-close" aria-label="Close" style="border:none;background:transparent;font-size:20px;cursor:pointer;">×</button>
     </div>
     <div style="padding:12px 16px;">


### PR DESCRIPTION
## Summary
- delegate the action bar merge click to a single handler that routes to contacts or partners
- extend merge core with partner-specific helpers and reuse the merge modal title for partners
- add a partners merge orchestrator that updates references before removing the loser record

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e46782087c8326979efc7d5ba3081f