### PR TITLE
feat: stabilize notifications API and tab wiring

### DIFF
--- a/crm-app/js/notifications.js
+++ b/crm-app/js/notifications.js
@@ -566,16 +566,7 @@
     const queue = await buildQueue();
     __lastQueue = queue;
     await syncQueueStore(queue);
-    if(typeof window !== 'undefined'){
-      try{ window.__NOTIF_QUEUE__ = queue.slice(); }
-      catch(_){ window.__NOTIF_QUEUE__ = queue; }
-    }
     renderNotificationsList(queue);
-    if(typeof window !== 'undefined' && typeof window.dispatchEvent === 'function'){
-      try{
-        window.dispatchEvent(new CustomEvent('notifications:changed', { detail: { count: queue.length, queue } }));
-      }catch(_){ }
-    }
   }
 
   window.renderNotifications = renderNotifications;

--- a/crm-app/js/pages/email_templates.js
+++ b/crm-app/js/pages/email_templates.js
@@ -165,9 +165,9 @@ export function renderEmailTemplates(root) {
       const record = Templates.upsert({ id, name, subject, body });
       currentId = record.id;
       try {
-        const { Notifier } = await import('/js/notifications/notifier.js');
-        if (Notifier && typeof Notifier.push === 'function') {
-          Notifier.push({ type: 'templates', title: 'Template saved' });
+        const { pushNotification } = await import('/js/notifications/notifier.js');
+        if (typeof pushNotification === 'function') {
+          pushNotification({ type: 'templates', title: 'Template saved' });
         }
       } catch {}
     }

--- a/crm-app/js/pages/notifications.js
+++ b/crm-app/js/pages/notifications.js
@@ -1,49 +1,167 @@
-import { Notifier } from '../notifications/notifier.js';
+import { listNotifications, clearNotifications, removeNotification, onNotificationsChanged } from '/js/notifications/notifier.js';
 
-function el(html){ const t=document.createElement('template'); t.innerHTML=html.trim(); return t.content.firstElementChild; }
-function fmt(ts){ try{ return new Date(ts).toLocaleString(); }catch(_){ return String(ts||''); } }
+function fmt(ts){
+  if (!ts && ts !== 0) return '';
+  try {
+    const date = new Date(ts);
+    if (Number.isNaN(date.getTime())) return String(ts || '');
+    return date.toLocaleString();
+  } catch (_) {
+    return String(ts || '');
+  }
+}
 
-export function renderNotifications(root){
-  if(!root) return;
-  root.innerHTML = `
-    <section data-notifs role="region" aria-label="Notifications">
-      <header style="display:flex;gap:8px;align-items:center;justify-content:space-between;">
-        <h3 style="margin:0;">Notifications</h3>
-        <div>
-          <button data-act="markread">Mark all read</button>
-          <button data-act="clear">Clear</button>
-        </div>
-      </header>
-      <div class="list" style="margin-top:12px;"></div>
-    </section>
-  `;
-  const list = root.querySelector('.list');
+function createLayout(){
+  const section = document.createElement('section');
+  section.setAttribute('data-notifs', '');
+  section.setAttribute('role', 'region');
+  section.setAttribute('aria-label', 'Notifications');
 
-  function paint(state){
-    const items = state.items;
-    if (!items.length){ list.innerHTML = `<div role="note">No notifications yet.</div>`; return; }
-    const ul = el(`<ul style="list-style:none;padding:0;margin:0;"></ul>`);
-    items.forEach(n => {
-      const li = el(`<li style="padding:8px 0;border-bottom:1px solid rgba(0,0,0,0.06);"></li>`);
-      li.innerHTML = `
-        <div style="display:flex;justify-content:space-between;gap:12px;">
-          <div><strong>${n.title}</strong></div>
-          <div style="opacity:0.7;">${fmt(n.at)}</div>
-        </div>
-        <div style="font-size:12px;opacity:${n.read?0.5:0.9};">${n.type}</div>
-      `;
-      ul.appendChild(li);
-    });
-    list.replaceChildren(ul);
+  const header = document.createElement('header');
+  header.style.display = 'flex';
+  header.style.gap = '8px';
+  header.style.alignItems = 'center';
+  header.style.justifyContent = 'space-between';
+
+  const heading = document.createElement('h3');
+  heading.style.margin = '0';
+  heading.textContent = 'Notifications';
+  header.appendChild(heading);
+
+  const controls = document.createElement('div');
+  const clearBtn = document.createElement('button');
+  clearBtn.type = 'button';
+  clearBtn.setAttribute('data-act', 'clear-notifications');
+  clearBtn.textContent = 'Clear All';
+  controls.appendChild(clearBtn);
+  header.appendChild(controls);
+
+  const list = document.createElement('div');
+  list.className = 'list';
+  list.style.marginTop = '12px';
+  list.setAttribute('data-list', 'notifications');
+
+  section.append(header, list);
+  return { section, list, clearBtn };
+}
+
+function renderList(listEl){
+  const items = listNotifications();
+  if (!Array.isArray(items) || !items.length) {
+    const empty = document.createElement('div');
+    empty.setAttribute('role', 'note');
+    empty.textContent = 'No notifications yet.';
+    listEl.replaceChildren(empty);
+    return;
   }
 
-  const unsub = Notifier.subscribe(paint);
+  const ul = document.createElement('ul');
+  ul.style.listStyle = 'none';
+  ul.style.padding = '0';
+  ul.style.margin = '0';
 
-  root.querySelector('[data-act="markread"]').addEventListener('click', () => Notifier.markAllRead());
-  root.querySelector('[data-act="clear"]').addEventListener('click', () => Notifier.clearAll());
+  items.forEach((item) => {
+    const li = document.createElement('li');
+    li.style.padding = '8px 0';
+    li.style.borderBottom = '1px solid rgba(0,0,0,0.06)';
+    li.setAttribute('data-id', item.id || '');
 
-  // Clean up if the page gets unmounted
-  root.addEventListener('DOMNodeRemovedFromDocument', () => unsub(), { once:true });
+    const header = document.createElement('div');
+    header.style.display = 'flex';
+    header.style.justifyContent = 'space-between';
+    header.style.gap = '12px';
+    header.style.alignItems = 'center';
+
+    const titleWrap = document.createElement('div');
+    const title = document.createElement('strong');
+    title.textContent = item.title || '(untitled notification)';
+    titleWrap.appendChild(title);
+
+    const actionsWrap = document.createElement('div');
+    actionsWrap.style.display = 'flex';
+    actionsWrap.style.gap = '8px';
+    actionsWrap.style.alignItems = 'center';
+
+    const time = document.createElement('div');
+    time.style.opacity = '0.7';
+    time.textContent = fmt(item.ts);
+    actionsWrap.appendChild(time);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.setAttribute('data-act', 'notif-remove');
+    removeBtn.setAttribute('data-id', item.id || '');
+    removeBtn.textContent = 'Remove';
+    actionsWrap.appendChild(removeBtn);
+
+    header.append(titleWrap, actionsWrap);
+
+    const metaLine = document.createElement('div');
+    metaLine.style.fontSize = '12px';
+    metaLine.style.opacity = '0.8';
+    metaLine.textContent = item.type || 'info';
+
+    li.append(header, metaLine);
+    ul.appendChild(li);
+  });
+
+  listEl.replaceChildren(ul);
+}
+
+export function renderNotifications(root){
+  if (!root) return;
+
+  if (typeof root.__notifCleanup === 'function') {
+    try { root.__notifCleanup(); } catch (_) {}
+  }
+
+  const { section, list, clearBtn } = createLayout();
+  root.replaceChildren(section);
+
+  const raf = window.requestAnimationFrame || ((cb) => setTimeout(cb, 16));
+  const cancelRaf = window.cancelAnimationFrame || window.clearTimeout || clearTimeout;
+  let frame = null;
+  const apply = () => {
+    if (frame !== null) return;
+    frame = raf(() => {
+      frame = null;
+      try { renderList(list); } catch (_) {}
+    });
+  };
+
+  const unsub = onNotificationsChanged(apply);
+  const clearHandler = () => {
+    try { clearNotifications(); } catch (_) {}
+  };
+  clearBtn.addEventListener('click', clearHandler);
+
+  const clickHandler = (event) => {
+    const btn = event.target && typeof event.target.closest === 'function'
+      ? event.target.closest('[data-act="notif-remove"]')
+      : null;
+    if (!btn) return;
+    const id = btn.getAttribute('data-id');
+    if (!id) return;
+    removeNotification(id);
+  };
+  section.addEventListener('click', clickHandler);
+
+  const cleanup = () => {
+    if (typeof unsub === 'function') {
+      try { unsub(); } catch (_) {}
+    }
+    clearBtn.removeEventListener('click', clearHandler);
+    section.removeEventListener('click', clickHandler);
+    if (frame !== null) {
+      try { cancelRaf(frame); } catch (_) {}
+    }
+    frame = null;
+  };
+
+  root.__notifCleanup = cleanup;
+  section.addEventListener('DOMNodeRemovedFromDocument', cleanup, { once: true });
+
+  apply();
 }
 
 export function initNotifications(){

--- a/crm-app/js/ui/notifications_panel.js
+++ b/crm-app/js/ui/notifications_panel.js
@@ -1,74 +1,22 @@
-(function(){
-  if(typeof window === 'undefined') return;
-  if(window.__WIRED_NOTIF_TAB_COUNT__) return;
+import { getNotificationsCount, onNotificationsChanged } from '/js/notifications/notifier.js';
+
+if (!window.__WIRED_NOTIF_TAB_COUNT__) {
   window.__WIRED_NOTIF_TAB_COUNT__ = true;
 
-  function setNotificationsTabCount(n){
-    const sel = [
-      '[data-tab="notifications"]',
-      'a[href="#notifications"]',
-      '.tab-notifications',
-      '#tab-notifications',
-      '[data-nav="notifications"]'
-    ];
+  function setTab(n) {
+    const sel = ['[data-tab="notifications"]','a[href="#notifications"]','.tab-notifications','#tab-notifications'];
     const tab = sel.map(s => document.querySelector(s)).find(Boolean);
-    if(!tab) return;
-    const base = 'Notifications';
-    const count = Number.isFinite(n) ? n : 0;
-    tab.textContent = count > 0 ? `${base}[${count}]` : base;
-    tab.setAttribute('data-count', String(count));
+    if (!tab) return;
+    const base = "Notifications";
+    tab.textContent = (n > 0) ? `${base}[${n}]` : base;
+    tab.setAttribute("data-count", String(n || 0));
   }
 
-  async function getNotificationsCount(){
-    try{
-      if(typeof window.getNotificationsCount === 'function'){
-        const value = await window.getNotificationsCount();
-        if(Number.isFinite(value)) return value;
-      }
-    }catch(_){ }
+  const raf = window.requestAnimationFrame || (cb => setTimeout(cb,16));
+  const apply = () => { try { setTab(getNotificationsCount()); } catch(_) {} };
 
-    try{
-      if(Array.isArray(window.__NOTIF_QUEUE__)){
-        return window.__NOTIF_QUEUE__.length;
-      }
-    }catch(_){ }
-
-    try{
-      if(window.Notifier && typeof window.Notifier.unread === 'function'){
-        const unread = window.Notifier.unread();
-        if(Number.isFinite(unread)) return unread;
-      }
-      if(window.Notifier && Array.isArray(window.Notifier.queue)){
-        return window.Notifier.queue.length;
-      }
-    }catch(_){ }
-
-    try{
-      if(typeof window.dbCount === 'function'){
-        const c = await window.dbCount('notifications');
-        if(Number.isFinite(c)) return c;
-      }
-    }catch(_){ }
-
-    try{
-      const nodes = document.querySelectorAll('[data-notification-row], .notification-row');
-      return nodes.length || 0;
-    }catch(_){ }
-
-    return 0;
-  }
-
-  const raf = window.requestAnimationFrame || (cb => setTimeout(cb, 16));
-
-  async function applyNotifCount(){
-    try{
-      const count = await getNotificationsCount();
-      setNotificationsTabCount(count);
-    }catch(_){ }
-  }
-
-  try{ window.addEventListener('notifications:changed', applyNotifCount); }catch(_){ }
-  try{ window.addEventListener('app:data:changed', applyNotifCount); }catch(_){ }
-
-  raf(() => raf(applyNotifCount));
-})();
+  // Listen to our API event and general app updates
+  onNotificationsChanged(apply);
+  try { window.addEventListener("app:data:changed", apply); } catch(_) {}
+  raf(() => raf(apply));
+}


### PR DESCRIPTION
## Summary
- replace the notifier implementation with a storage-backed API that emits change events and exports helper functions
- update the notifications page and navigation tab wiring to consume the new API and avoid reduce-on-undefined crashes
- adjust callers to push notifications through the shared API and remove legacy global queue mutation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e46ebf7fc483269472be157adf84b7