### PR TITLE
Sync notification queue with notifier API

### DIFF
--- a/crm-app/js/notifications/notifier.js
+++ b/crm-app/js/notifications/notifier.js
@@ -51,6 +51,13 @@ const Notifier = (function() {
       queue.push(n);
       emit(); return true;
     },
+    replace(list) {
+      const next = Array.isArray(list) ? list.map(normalizeItem).filter(Boolean) : [];
+      queue.length = 0;
+      Array.prototype.push.apply(queue, next);
+      emit();
+      return queue.length;
+    },
     remove(id) {
       if (!id) return false;
       const before = queue.length;
@@ -77,6 +84,7 @@ window.Notifier = window.Notifier || Notifier;
 export const getNotificationsCount = () => Notifier.getCount();
 export const listNotifications       = () => Notifier.list();
 export const pushNotification        = (item) => Notifier.push(item);
+export const replaceNotifications    = (list) => Notifier.replace(list);
 export const removeNotification      = (id) => Notifier.remove(id);
 export const clearNotifications      = () => Notifier.clear();
 export const onNotificationsChanged  = (h) => Notifier.onChanged(h);


### PR DESCRIPTION
## Summary
- convert the rebuilt notifications queue into notifier entries and publish them through the notifier API
- fall back to legacy globals/events when the notifier is unavailable so other listeners still refresh
- extend the notifier with a replace method and export to support bulk queue updates

## Testing
- npm test -- --runInBand *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68e473144b44832697c31c397379bfce