### PR TITLE
Fix notifications tab count wiring

### DIFF
--- a/crm-app/js/ui/notifications_panel.js
+++ b/crm-app/js/ui/notifications_panel.js
@@ -4,7 +4,7 @@ if (!window.__WIRED_NOTIF_TAB_COUNT__) {
   window.__WIRED_NOTIF_TAB_COUNT__ = true;
 
   function setTab(n) {
-    const sel = ['[data-tab="notifications"]','a[href="#notifications"]','.tab-notifications','#tab-notifications'];
+    const sel = ['[data-nav="notifications"]','[data-tab="notifications"]','a[href="#notifications"]','.tab-notifications','#tab-notifications'];
     const tab = sel.map(s => document.querySelector(s)).find(Boolean);
     if (!tab) return;
     const base = "Notifications";


### PR DESCRIPTION
## Summary
- include the main navigation button in the notification tab selector so counts can render next to the label

## Testing
- npm run test:unit *(fails: known baseline module resolution issues in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68e47d6a1a888326a141494fd9f178ce