### PR TITLE
Ensure calendar export modules load in boot manifest

### DIFF
--- a/crm-app/js/boot/manifest.js
+++ b/crm-app/js/boot/manifest.js
@@ -35,6 +35,8 @@ export const CORE = [
   "/js/notifications.js",
   "/js/calendar_impl.js",
   "/js/calendar.js",
+  "/js/calendar_ics.js",
+  "/js/calendar_actions.js",
   "/js/post_funding.js",
   "/js/qa.js",
   "/js/bulk_log.js",
@@ -64,7 +66,6 @@ export const PATCHES = [
   "/js/patch_2025-10-02_medium_nice.js",
   "/js/patch_2025-09-27_merge_ui.js",
   "/js/patch_2025-09-27_phase6_polish_telemetry.js",
-  "/js/patch_2025-10-03_calendar_ics_button.js",
   "/js/patch_2025-10-03_quick_add_partner.js",
   "/js/patch_2025-10-03_automation_seed.js",
 ];


### PR DESCRIPTION
## Summary
- add the new calendar ICS utilities and action wiring to the boot manifest core bundle
- remove the legacy calendar ICS patch entry so the new handler is the active implementation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e48e33bcc0832696e9ab24abc9bede