### PR TITLE
Restore calendar ICS export button

### DIFF
--- a/crm-app/index.html
+++ b/crm-app/index.html
@@ -900,9 +900,14 @@
       </span>
       <span class="grow">
       </span>
-      <button class="btn" id="cal-export" type="button">
-       Export CSV
-      </button>
+      <div class="row" style="gap:8px;align-items:center">
+       <button class="btn" data-act="calendar:export:ics" type="button">
+        Export .ics
+       </button>
+       <button class="btn" id="cal-export" type="button">
+        Export CSV
+       </button>
+      </div>
      </div>
      <div class="calendar-legend" id="calendar-legend">
      </div>


### PR DESCRIPTION
## Summary
- add a dedicated Calendar toolbar group that includes a data-act hook for the ICS export action
- ensure the new CORE calendar actions script has a target to attach its export handler so the UI button is rendered again alongside CSV export

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e48fca994c8326be000fdaca2405e3