### PR TITLE
Populate contactId on new V5 contacts

### DIFF
--- a/crm-app/js/importer_contacts.js
+++ b/crm-app/js/importer_contacts.js
@@ -198,6 +198,7 @@
       }
       merged.buyerPartnerId   = merged.buyerPartnerId   || buyerPartnerId;
       merged.listingPartnerId = merged.listingPartnerId || listingPartnerId;
+      merged.contactId = merged.contactId || merged.id;
       merged.updatedAt = Date.now();
       await putContact(merged);
       register(merged);
@@ -206,6 +207,7 @@
 
     const id = row.id || crypto?.randomUUID?.() || `c_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
     const rec = { id, ...row, buyerPartnerId, listingPartnerId };
+    rec.contactId = rec.contactId || rec.id;
     rec.createdAt = rec.createdAt || Date.now();
     await putContact(rec);
     register(rec);


### PR DESCRIPTION
## Summary
- ensure merged contacts backfill a missing contactId with their id
- set contactId on newly created contacts during V5 import prior to persisting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e49b1470dc8326a282ae466839324a