### PR TITLE
P6f: Seeds & snapshot utilities

### DIFF
--- a/crm-app/js/seed_data.js
+++ b/crm-app/js/seed_data.js
@@ -1,0 +1,34 @@
+/* P6f: Idempotent seeds */
+(function(){
+  if (window.__SEEDS_V1__) return; window.__SEEDS_V1__ = true;
+
+  async function upsert(store, key, row){
+    try {
+      const existing = await window.db.get(store, key).catch(()=>null);
+      const rec = existing ? { ...existing, ...row, id: key } : { id: key, ...row };
+      await window.db.put(store, rec);
+    } catch {
+      // localStorage fallback
+      const k = `seed:${store}`;
+      const all = JSON.parse(localStorage.getItem(k)||"{}");
+      all[key] = { ...(all[key]||{}), ...row, id:key };
+      localStorage.setItem(k, JSON.stringify(all));
+    }
+  }
+
+  async function runSeeds(){
+    // Deterministic keys
+    const p1="partner_acme_co", p2="partner_zen_realty";
+    const c1="contact_alex_m",  c2="contact_bailey_s";
+
+    await upsert("partners", p1, { name:"Acme Co", email:"acme@ex.com", phone:"5551112222" });
+    await upsert("partners", p2, { name:"Zen Realty", email:"zen@re.com", phone:"5553334444" });
+
+    await upsert("contacts", c1, { firstName:"Alex", lastName:"Morris", email:"alex@home.com", buyerPartnerId:p1, listingPartnerId:p2, loanType:"Conventional" });
+    await upsert("contacts", c2, { firstName:"Bailey", lastName:"Stone", email:"bailey@work.com", buyerPartnerId:p2, listingPartnerId:p1, loanType:"FHA" });
+
+    window.dispatchAppDataChanged?.("seeds:complete");
+  }
+
+  window.Seeds = { runSeeds };
+})();

--- a/crm-app/js/snapshot.js
+++ b/crm-app/js/snapshot.js
@@ -1,0 +1,43 @@
+/* P6f: Snapshot export/restore */
+(function(){
+  if (window.__SNAPSHOT_V1__) return; window.__SNAPSHOT_V1__ = true;
+
+  async function exportJSON(){
+    const out = { contacts:[], partners:[], events:[], documents:[] };
+    try {
+      out.contacts  = await window.db.getAll?.("contacts")  || out.contacts;
+      out.partners  = await window.db.getAll?.("partners")  || out.partners;
+      out.events    = await window.db.getAll?.("events")    || out.events;
+      out.documents = await window.db.getAll?.("documents") || out.documents;
+    } catch {}
+    const blob = new Blob([JSON.stringify(out,null,2)], {type:"application/json"});
+    const url  = URL.createObjectURL(blob);
+    const a = document.createElement("a"); a.href=url; a.download=`crm_snapshot_${Date.now()}.json`; document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url);
+  }
+
+  async function restoreJSON(file){
+    const json = await file.text();
+    const data = JSON.parse(json);
+    async function putAll(store, rows){
+      for (const r of (rows||[])){ try { await window.db.put(store, r); } catch {} }
+    }
+    await putAll("partners",  data.partners);
+    await putAll("contacts",  data.contacts);
+    await putAll("events",    data.events);
+    await putAll("documents", data.documents);
+    window.dispatchAppDataChanged?.("snapshot:restore");
+  }
+
+  // Wiring (delegated; no HTML edits)
+  document.addEventListener("click", (e)=>{
+    const ex = e.target?.closest?.('[data-act="snapshot:export"]');
+    if (ex){ e.preventDefault(); exportJSON(); }
+  }, true);
+
+  document.addEventListener("change", (e)=>{
+    const inp = e.target?.closest?.('input[type="file"][data-act="snapshot:restore"]');
+    if (inp && inp.files?.[0]) restoreJSON(inp.files[0]);
+  }, true);
+
+  window.Snapshot = { exportJSON, restoreJSON };
+})();


### PR DESCRIPTION
## Summary
- add idempotent seed helper that upserts deterministic partner and contact records and falls back to localStorage when IndexedDB is unavailable
- wire snapshot export and restore helpers that read/write CRM stores and trigger app refresh callbacks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e49c8b2340832681508ff8cf8f609d