### PR TITLE
Restore selection:changed event after merge

### DIFF
--- a/crm-app/js/contacts_merge_orchestrator.js
+++ b/crm-app/js/contacts_merge_orchestrator.js
@@ -168,7 +168,7 @@ export async function openContactsMergeByIds(idA, idB) {
           if (typeof window.SelectionService?.clear === "function") window.SelectionService.clear("merge");
         } catch(_) {}
         try {
-          const evt = new CustomEvent("selection:change", { detail: { clearedBy: "merge" }});
+          const evt = new CustomEvent("selection:changed", { detail: { clearedBy: "merge" }});
           window.dispatchEvent(evt);
         } catch(_) {}
         try {
@@ -191,7 +191,7 @@ export async function openContactsMergeByIds(idA, idB) {
           // Clear selection and repaint once
           try { window.Selection?.clear?.(); } catch(_) {}
           try {
-            const evt = new CustomEvent("selection:change", { detail: { clearedBy: "merge" }});
+            const evt = new CustomEvent("selection:changed", { detail: { clearedBy: "merge" }});
             window.dispatchEvent(evt);
           } catch(_) {}
           try { window.dispatchAppDataChanged?.("contacts:merge"); } catch(_) {}


### PR DESCRIPTION
## Summary
- restore the contacts merge orchestrator to dispatch the documented `selection:changed` event so selection consumers are notified

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e542ae724c8326b6fa645e7a19697d