### PR TITLE
Fix merge action bar wiring and events

### DIFF
--- a/crm-app/js/boot/manifest.js
+++ b/crm-app/js/boot/manifest.js
@@ -69,6 +69,7 @@ export const PATCHES = [
   "/js/patch_2025-10-03_quick_add_partner.js",
   "/js/patch_2025-10-03_automation_seed.js",
   "/js/patch_2025-10-07_wire_diag_and_stage_tracker.js",
+  "/js/patch_2025-10-07_actionbar_wiring_safety.js",
 ];
 
 export default {

--- a/crm-app/js/contacts_merge_orchestrator.js
+++ b/crm-app/js/contacts_merge_orchestrator.js
@@ -168,7 +168,7 @@ export async function openContactsMergeByIds(idA, idB) {
           if (typeof window.SelectionService?.clear === "function") window.SelectionService.clear("merge");
         } catch(_) {}
         try {
-          const evt = new CustomEvent("selection:changed", { detail: { clearedBy: "merge" }});
+          const evt = new CustomEvent("selection:change", { detail: { clearedBy: "merge" }});
           window.dispatchEvent(evt);
         } catch(_) {}
         try {
@@ -191,7 +191,7 @@ export async function openContactsMergeByIds(idA, idB) {
           // Clear selection and repaint once
           try { window.Selection?.clear?.(); } catch(_) {}
           try {
-            const evt = new CustomEvent("selection:changed", { detail: { clearedBy: "merge" }});
+            const evt = new CustomEvent("selection:change", { detail: { clearedBy: "merge" }});
             window.dispatchEvent(evt);
           } catch(_) {}
           try { window.dispatchAppDataChanged?.("contacts:merge"); } catch(_) {}

--- a/crm-app/js/patch_2025-10-07_actionbar_wiring_safety.js
+++ b/crm-app/js/patch_2025-10-07_actionbar_wiring_safety.js
@@ -1,0 +1,66 @@
+(() => {
+  if (window.__WIRED_ACTIONBAR_SAFETY__) return;
+  window.__WIRED_ACTIONBAR_SAFETY__ = true;
+
+  const DEBUG = !!(window.__ENV__?.DEBUG);
+
+  function getSelection() {
+    try {
+      const sel = window.selectionService?.get?.(document.body.getAttribute("data-scope") || "contacts");
+      if (Array.isArray(sel)) return { ids: sel, type: "contacts" };
+      if (Array.isArray(sel?.ids)) return { ids: sel.ids, type: sel.type || "contacts" };
+    } catch {}
+    return { ids: [], type: "contacts" };
+  }
+
+  function recalcEnablement() {
+    const { ids, type } = getSelection();
+    const bar = document.querySelector('[data-role="actionbar"]');
+    if (!bar) return;
+    const mergeBtn = bar.querySelector('[data-act="merge"]');
+    if (mergeBtn) {
+      const on = ids.length === 2; // merge only with exactly 2
+      mergeBtn.toggleAttribute("aria-disabled", !on);
+      mergeBtn.toggleAttribute("data-enabled", on);
+      mergeBtn.classList.toggle("is-disabled", !on);
+    }
+    // You can extend here for other action buttons if needed
+    if (DEBUG) { /* no noisy logs in prod */ }
+  }
+
+  // Keep state fresh on selection changes and app repaints
+  window.addEventListener("selection:change", recalcEnablement);
+  document.addEventListener("app:data:changed", recalcEnablement);
+  document.addEventListener("DOMContentLoaded", recalcEnablement, { once: true });
+
+  // Delegated click handler for merge that routes by selection type
+  document.addEventListener("click", (ev) => {
+    const btn = ev.target?.closest?.('[data-act="merge"]');
+    if (!btn) return;
+    ev.preventDefault();
+    const { ids, type } = getSelection();
+    if (ids.length !== 2) return; // do nothing unless exactly two
+
+    try {
+      if (type === "partners" && window.PartnersMergeOrchestrator?.mergeIds) {
+        window.PartnersMergeOrchestrator.mergeIds(ids).then(() => {
+          window.dispatchAppDataChanged?.("partners:merge");
+        });
+      } else if (type === "contacts" && window.ContactsMergeOrchestrator?.mergeIds) {
+        window.ContactsMergeOrchestrator.mergeIds(ids).then(() => {
+          window.dispatchAppDataChanged?.("contacts:merge");
+        });
+      } else {
+        // Fallback: try both orchestrators best-effort
+        const p = window.PartnersMergeOrchestrator?.mergeIds?.(ids);
+        const c = window.ContactsMergeOrchestrator?.mergeIds?.(ids);
+        Promise.allSettled([p, c]).then(() => window.dispatchAppDataChanged?.("merge:attempt"));
+      }
+    } catch (e) {
+      if (DEBUG) console.warn("[actionbar] merge click handler error", e);
+    }
+  }, true);
+
+  // First paint
+  queueMicrotask(recalcEnablement);
+})();


### PR DESCRIPTION
## Summary
- align the contacts merge orchestrator with the shared `selection:change` event name after merges
- add an action bar safety patch that keeps merge enablement synchronized and delegates merge clicks to the correct orchestrator
- register the new safety patch in the boot manifest so it loads with the rest of the defensive patches

## Testing
- npm run test:unit *(fails: existing vitest environment issues such as missing browser globals and unresolved module paths)*

------
https://chatgpt.com/codex/tasks/task_e_68e5447af5b48326a6970feb559b5c34