### PR TITLE
Add profile photo persistence and header avatar support

### DIFF
--- a/crm-app/js/boot/manifest.js
+++ b/crm-app/js/boot/manifest.js
@@ -70,6 +70,7 @@ export const PATCHES = [
   "/js/patch_2025-10-03_automation_seed.js",
   "/js/patch_2025-10-07_wire_diag_and_stage_tracker.js",
   "/js/patch_2025-10-07_actionbar_wiring_safety.js",
+  "/js/patch_2025-10-07_settings_profile_photo_ui.js",
 ];
 
 export default {

--- a/crm-app/js/patch_2025-10-07_settings_profile_photo_ui.js
+++ b/crm-app/js/patch_2025-10-07_settings_profile_photo_ui.js
@@ -1,0 +1,212 @@
+import { SettingsPhoto } from "/js/settings_profile_photo.js";
+
+(() => {
+  if (typeof window === "undefined") return;
+  if (window.__WIRED_SETTINGS_PHOTO_UI__) return;
+  window.__WIRED_SETTINGS_PHOTO_UI__ = true;
+
+  function updatePreview(refs, dataUrl) {
+    if (!refs) return;
+    const value = typeof dataUrl === "string" ? dataUrl : "";
+    if (value) {
+      refs.preview.src = value;
+      refs.preview.style.display = "inline-block";
+      refs.preview.hidden = false;
+      refs.remove.hidden = false;
+    } else {
+      refs.preview.removeAttribute("src");
+      refs.preview.style.display = "none";
+      refs.preview.hidden = true;
+      refs.remove.hidden = true;
+    }
+  }
+
+  function readCurrentRefs(field) {
+    if (!field) return null;
+    if (field.__profilePhotoRefs) return field.__profilePhotoRefs;
+    const input = field.querySelector('input[type="file"]');
+    const preview = field.querySelector('img[data-role="profile-photo-preview"]');
+    const remove = field.querySelector('button[data-action="remove-photo"]');
+    if (!input || !preview || !remove) return null;
+    field.__profilePhotoRefs = { field, input, preview, remove };
+    return field.__profilePhotoRefs;
+  }
+
+  function ensureUploader() {
+    if (typeof document === "undefined") return null;
+    const card = document.getElementById("lo-profile-settings");
+    if (!card) return null;
+    const grid = card.querySelector(".grid");
+    let field = card.querySelector('[data-role="profile-photo-uploader"]');
+    if (!field) {
+      field = document.createElement("label");
+      field.setAttribute("data-role", "profile-photo-uploader");
+      field.style.display = "block";
+      field.style.padding = "4px 0";
+
+      const title = document.createElement("span");
+      title.textContent = "Profile Photo";
+      title.style.display = "block";
+      title.style.marginBottom = "4px";
+      title.style.fontWeight = "500";
+
+      const controls = document.createElement("div");
+      controls.style.display = "flex";
+      controls.style.alignItems = "center";
+      controls.style.gap = "12px";
+
+      const input = document.createElement("input");
+      input.type = "file";
+      input.accept = "image/*";
+      input.style.maxWidth = "100%";
+
+      const preview = document.createElement("img");
+      preview.setAttribute("data-role", "profile-photo-preview");
+      preview.alt = "Profile photo preview";
+      preview.style.width = "48px";
+      preview.style.height = "48px";
+      preview.style.borderRadius = "50%";
+      preview.style.objectFit = "cover";
+      preview.style.display = "none";
+      preview.loading = "lazy";
+
+      const remove = document.createElement("button");
+      remove.type = "button";
+      remove.setAttribute("data-action", "remove-photo");
+      remove.textContent = "Remove";
+      remove.style.background = "none";
+      remove.style.border = "0";
+      remove.style.padding = "0";
+      remove.style.fontSize = "0.85rem";
+      remove.style.color = "var(--link-color, #1a73e8)";
+      remove.style.cursor = "pointer";
+      remove.style.textDecoration = "underline";
+      remove.hidden = true;
+
+      controls.appendChild(input);
+      controls.appendChild(preview);
+      controls.appendChild(remove);
+
+      field.appendChild(title);
+      field.appendChild(controls);
+
+      if (grid) {
+        grid.appendChild(field);
+      } else {
+        card.appendChild(field);
+      }
+    }
+
+    const refs = readCurrentRefs(field);
+    if (!refs) return null;
+
+    if (!refs.__wired) {
+      refs.__wired = true;
+      refs.input.addEventListener("change", (event) => {
+        const file = event.target && event.target.files ? event.target.files[0] : null;
+        if (!file) return;
+        if (file.type && !/^image\//i.test(file.type)) {
+          event.target.value = "";
+          return;
+        }
+        const reader = new FileReader();
+        reader.addEventListener("load", () => {
+          const dataUrl = typeof reader.result === "string" ? reader.result : "";
+          if (!dataUrl) return;
+          SettingsPhoto.saveDataUrl(dataUrl);
+          updatePreview(refs, dataUrl);
+          try { event.target.value = ""; }
+          catch (_) {}
+        });
+        reader.addEventListener("error", () => {
+          try { event.target.value = ""; }
+          catch (_) {}
+        });
+        reader.readAsDataURL(file);
+      });
+
+      refs.remove.addEventListener("click", () => {
+        SettingsPhoto.saveDataUrl("", { notifyApp: true });
+        updatePreview(refs, "");
+      });
+    }
+
+    updatePreview(refs, SettingsPhoto.loadDataUrl());
+    return refs;
+  }
+
+  function renderHeaderAvatar() {
+    if (typeof document === "undefined") return;
+    const chip = document.getElementById("lo-profile-chip");
+    if (!chip) return;
+    const nameEl = chip.querySelector('[data-role="lo-name"]');
+    if (!nameEl) return;
+    const dataUrl = SettingsPhoto.loadDataUrl();
+    if (dataUrl) {
+      if (!nameEl.__photoOriginal) {
+        nameEl.__photoOriginal = {
+          display: nameEl.style.display || "",
+          alignItems: nameEl.style.alignItems || "",
+          gap: nameEl.style.gap || "",
+        };
+      }
+      nameEl.style.display = "flex";
+      nameEl.style.alignItems = "center";
+      nameEl.style.gap = "8px";
+      let img = nameEl.querySelector('img[data-role="lo-photo"]');
+      if (!img) {
+        img = document.createElement("img");
+        img.dataset.role = "lo-photo";
+        img.alt = "Profile photo";
+        img.style.width = "28px";
+        img.style.height = "28px";
+        img.style.borderRadius = "50%";
+        img.style.objectFit = "cover";
+        img.style.flexShrink = "0";
+        nameEl.insertBefore(img, nameEl.firstChild);
+      }
+      img.src = dataUrl;
+      nameEl.__photoFlexApplied = true;
+    } else {
+      const existing = nameEl.querySelector('img[data-role="lo-photo"]');
+      if (existing) existing.remove();
+      if (nameEl.__photoFlexApplied) {
+        const original = nameEl.__photoOriginal || {};
+        nameEl.style.display = original.display || "";
+        nameEl.style.alignItems = original.alignItems || "";
+        nameEl.style.gap = original.gap || "";
+        nameEl.__photoOriginal = null;
+      }
+      nameEl.__photoFlexApplied = false;
+    }
+  }
+
+  function syncAll() {
+    ensureUploader();
+    renderHeaderAvatar();
+  }
+
+  function handleStored(event) {
+    const detail = event && event.detail ? event.detail : {};
+    const dataUrl = typeof detail.dataUrl === "string" ? detail.dataUrl : "";
+    const refs = ensureUploader();
+    updatePreview(refs, dataUrl);
+    renderHeaderAvatar();
+  }
+
+  function handleAppDataChanged(event) {
+    const scope = event && event.detail && event.detail.scope;
+    if (scope && scope !== "settings") return;
+    syncAll();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", syncAll, { once: true });
+  } else {
+    syncAll();
+  }
+
+  document.addEventListener("settings:profile-photo:stored", handleStored);
+  document.addEventListener("app:data:changed", handleAppDataChanged);
+  window.RenderGuard?.registerHook?.(syncAll);
+})();

--- a/crm-app/js/settings_forms.js
+++ b/crm-app/js/settings_forms.js
@@ -1,4 +1,5 @@
 import { STR, text } from './ui/strings.js';
+import { SettingsPhoto } from './settings_profile_photo.js';
 const __STR_FALLBACK__ = (window.STR && typeof window.STR === 'object') ? window.STR : {};
 function __textFallback__(k){ try { return (STR && STR[k]) || (__STR_FALLBACK__[k]) || k; } catch(_){ return k; } }
 
@@ -442,9 +443,12 @@ function __textFallback__(k){ try { return (STR && STR[k]) || (__STR_FALLBACK__[
     profileState.name = mergedProfile && mergedProfile.name ? mergedProfile.name : '';
     profileState.email = mergedProfile && mergedProfile.email ? mergedProfile.email : '';
     profileState.phone = mergedProfile && mergedProfile.phone ? mergedProfile.phone : '';
-    profileState.photoDataUrl = typeof mergedProfile.photoDataUrl === 'string' ? mergedProfile.photoDataUrl : '';
+    const mergedPhoto = typeof mergedProfile.photoDataUrl === 'string' ? mergedProfile.photoDataUrl : '';
+    const persistedPhoto = SettingsPhoto.loadDataUrl();
+    profileState.photoDataUrl = persistedPhoto || mergedPhoto || '';
     const storedSignature = readSignatureLocal();
     profileState.signature = storedSignature || (mergedProfile && mergedProfile.signature ? mergedProfile.signature : '');
+    SettingsPhoto.saveDataUrl(profileState.photoDataUrl, { broadcast: false });
     if(nameInput) nameInput.value = profileState.name;
     if(emailInput) emailInput.value = profileState.email;
     if(phoneInput) phoneInput.value = profileState.phone;
@@ -506,6 +510,13 @@ function __textFallback__(k){ try { return (STR && STR[k]) || (__STR_FALLBACK__[
     const scope = evt && evt.detail && evt.detail.scope;
     if(scope && scope !== 'settings') return;
     hydrateAll();
+  });
+
+  document.addEventListener('settings:profile-photo:stored', evt => {
+    const detail = evt && evt.detail ? evt.detail : {};
+    const dataUrl = typeof detail.dataUrl === 'string' ? detail.dataUrl : '';
+    profileState.photoDataUrl = dataUrl;
+    renderProfileBadge();
   });
 })();
   function readProfileLocal(){

--- a/crm-app/js/settings_profile_photo.js
+++ b/crm-app/js/settings_profile_photo.js
@@ -1,0 +1,186 @@
+const PROFILE_KEY = "profile:v1";
+const PHOTO_KEY = "profile.photoDataUrl";
+
+function normalizeDataUrl(dataUrl) {
+  return typeof dataUrl === "string" ? dataUrl : "";
+}
+
+function cloneProfile(source) {
+  return source && typeof source === "object" ? Object.assign({}, source) : {};
+}
+
+function readProfileLocal() {
+  try {
+    const raw = localStorage.getItem(PROFILE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function writeProfileLocal(profile) {
+  try {
+    if (profile && typeof profile === "object" && Object.keys(profile).length) {
+      localStorage.setItem(PROFILE_KEY, JSON.stringify(profile));
+    } else {
+      localStorage.removeItem(PROFILE_KEY);
+    }
+  } catch (_) {}
+}
+
+function applyPhotoValue(profile, dataUrl) {
+  const next = cloneProfile(profile);
+  if (dataUrl) {
+    next.photoDataUrl = dataUrl;
+  } else {
+    delete next.photoDataUrl;
+  }
+  return next;
+}
+
+function updateSettingsStore(dataUrl) {
+  if (typeof window === "undefined") return;
+  try {
+    const getter = window.SettingsStore?.get;
+    const setter = window.SettingsStore?.set;
+    if (typeof getter !== "function" || typeof setter !== "function") return;
+    const current = getter() || {};
+    const next = Object.assign({}, current);
+    if (current.profile || current.loProfile) {
+      if (current.profile) {
+        next.profile = applyPhotoValue(current.profile, dataUrl);
+      }
+      if (current.loProfile) {
+        next.loProfile = applyPhotoValue(current.loProfile, dataUrl);
+      }
+    } else {
+      next.profile = applyPhotoValue({}, dataUrl);
+      next.loProfile = applyPhotoValue({}, dataUrl);
+    }
+    setter(next);
+  } catch (_) {}
+}
+
+function updateLocalProfile(dataUrl) {
+  const localProfile = readProfileLocal();
+  if (!localProfile && !dataUrl) return;
+  const next = applyPhotoValue(localProfile || {}, dataUrl);
+  writeProfileLocal(next);
+}
+
+function updateGlobalProfile(dataUrl) {
+  if (typeof window === "undefined") return;
+  try {
+    if (window.__LO_PROFILE__ && typeof window.__LO_PROFILE__ === "object") {
+      window.__LO_PROFILE__ = applyPhotoValue(window.__LO_PROFILE__, dataUrl);
+    }
+  } catch (_) {}
+}
+
+function readFallbackPhoto() {
+  try {
+    const stored = localStorage.getItem(PHOTO_KEY);
+    return typeof stored === "string" ? stored : "";
+  } catch (_) {
+    return "";
+  }
+}
+
+function writeFallbackPhoto(dataUrl) {
+  try {
+    if (dataUrl) {
+      localStorage.setItem(PHOTO_KEY, dataUrl);
+    } else {
+      localStorage.removeItem(PHOTO_KEY);
+    }
+  } catch (_) {}
+}
+
+function dispatchStoredEvent(dataUrl, broadcastOptions) {
+  if (typeof document === "undefined") return;
+  try {
+    const detail = { dataUrl };
+    document.dispatchEvent(new CustomEvent("settings:profile-photo:stored", { detail }));
+    if (broadcastOptions?.notifyApp !== false) {
+      const scopeDetail = { scope: "settings", source: "profile:photo", dataUrl };
+      const globalWindow = typeof window !== "undefined" ? window : undefined;
+      if (globalWindow && typeof globalWindow.dispatchAppDataChanged === "function") {
+        try {
+          globalWindow.dispatchAppDataChanged(scopeDetail);
+        } catch (_) {
+          document.dispatchEvent(new CustomEvent("app:data:changed", { detail: scopeDetail }));
+        }
+      } else {
+        document.dispatchEvent(new CustomEvent("app:data:changed", { detail: scopeDetail }));
+      }
+    }
+  } catch (_) {}
+}
+
+function resolvePhotoFromStore() {
+  if (typeof window === "undefined") return "";
+  try {
+    const store = window.SettingsStore?.get?.();
+    if (store && typeof store === "object") {
+      const profile = store.loProfile || store.profile;
+      if (profile && typeof profile.photoDataUrl === "string" && profile.photoDataUrl) {
+        return profile.photoDataUrl;
+      }
+    }
+  } catch (_) {}
+  return "";
+}
+
+function resolvePhotoFromGlobal() {
+  if (typeof window === "undefined") return "";
+  try {
+    const profile = window.__LO_PROFILE__;
+    if (profile && typeof profile === "object" && typeof profile.photoDataUrl === "string" && profile.photoDataUrl) {
+      return profile.photoDataUrl;
+    }
+  } catch (_) {}
+  return "";
+}
+
+function resolvePhotoFromProfileLocal() {
+  const profile = readProfileLocal();
+  if (profile && typeof profile.photoDataUrl === "string" && profile.photoDataUrl) {
+    return profile.photoDataUrl;
+  }
+  return "";
+}
+
+function loadDataUrl() {
+  return (
+    resolvePhotoFromGlobal() ||
+    resolvePhotoFromStore() ||
+    resolvePhotoFromProfileLocal() ||
+    readFallbackPhoto() ||
+    ""
+  );
+}
+
+function saveDataUrl(dataUrl, options = {}) {
+  const normalized = normalizeDataUrl(dataUrl);
+  const current = loadDataUrl();
+  const changed = normalized !== current;
+
+  updateSettingsStore(normalized);
+  updateLocalProfile(normalized);
+  updateGlobalProfile(normalized);
+  writeFallbackPhoto(normalized);
+
+  if (changed && options.broadcast !== false) {
+    dispatchStoredEvent(normalized, { notifyApp: options.notifyApp !== false });
+  }
+  return normalized;
+}
+
+export const SettingsPhoto = {
+  saveDataUrl,
+  loadDataUrl,
+};
+
+export default SettingsPhoto;


### PR DESCRIPTION
## Summary
- add a SettingsPhoto helper to persist profile photo data across local storage and the app store
- inject a profile photo uploader into the settings profile card and render the avatar in the header
- hydrate settings forms with stored photo data and react to photo change events

## Testing
- npm run test:unit *(fails: environment missing browser-only modules during Vitest run)*

------
https://chatgpt.com/codex/tasks/task_e_68e5594001988326859976d05b6a68ca