### PR TITLE
Polish launcher exit and center action bar

### DIFF
--- a/crm-app/js/patch_2025-10-07_actionbar_center.js
+++ b/crm-app/js/patch_2025-10-07_actionbar_center.js
@@ -1,0 +1,19 @@
+(() => {
+  if (window.__WIRED_ACTIONBAR_CENTER__) return;
+  window.__WIRED_ACTIONBAR_CENTER__ = true;
+
+  function center() {
+    const bar = document.querySelector('[data-role="actionbar"]');
+    if (!bar) return;
+    // Non-invasive centering: flex container with gap, applied inline
+    const s = bar.style;
+    s.display = s.display || "flex";
+    s.justifyContent = "center";
+    s.alignItems = "center";
+    s.gap = s.gap || "8px";
+    s.margin = s.margin || "8px auto";
+    s.width = s.width || "100%";
+  }
+  document.addEventListener("DOMContentLoaded", center, { once: true });
+  document.addEventListener("app:data:changed", center);
+})();

--- a/tools/Start-CRM.ps1
+++ b/tools/Start-CRM.ps1
@@ -251,6 +251,14 @@ try {
     exit 1
   } else {
     Write-Log "[EXIT] success."
+    try {
+      # If we reached here, server is up and browser launched; exit this host so the console closes.
+      if (-not $env:CRM_DEBUG -and -not $DebugPreference) {
+        Start-Sleep -Seconds 1
+        $host.SetShouldExit(0)
+        exit
+      }
+    } catch { }
     exit 0
   }
 }


### PR DESCRIPTION
## Summary
- ensure the PowerShell launcher requests the host to exit after a successful browser launch when not in debug mode
- add a JS patch that centers the action bar with idempotent inline flex styling hooks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e56626ebec83268e675f2409ce814d