### PR TITLE
Fix launcher exit guard

### DIFF
--- a/tools/Start-CRM.ps1
+++ b/tools/Start-CRM.ps1
@@ -253,7 +253,8 @@ try {
     Write-Log "[EXIT] success."
     try {
       # If we reached here, server is up and browser launched; exit this host so the console closes.
-      if (-not $env:CRM_DEBUG -and -not $DebugPreference) {
+      # Respect the explicit CRM_DEBUG escape hatch so developers can keep the host open when needed.
+      if (-not $env:CRM_DEBUG) {
         Start-Sleep -Seconds 1
         $host.SetShouldExit(0)
         exit


### PR DESCRIPTION
## Summary
- ensure the launcher exit guard does not depend on `$DebugPreference`
- document the `CRM_DEBUG` escape hatch for keeping the host open

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5697d9fe48326929122a9681edb55