### PR TITLE
Fix merge action bar wiring and events follow-up

### DIFF
--- a/crm-app/js/patch_2025-10-07_actionbar_wiring_safety.js
+++ b/crm-app/js/patch_2025-10-07_actionbar_wiring_safety.js
@@ -4,10 +4,22 @@
 
   const DEBUG = !!(window.__ENV__?.DEBUG);
 
+  function resolveSelectionService() {
+    const svc = window.SelectionService ?? window.Selection ?? window.selectionService;
+    if (svc && !window.SelectionService && window.selectionService === svc) {
+      try {
+        window.SelectionService = svc;
+      } catch (err) {
+        if (DEBUG) console.warn("[actionbar] unable to promote selection service", err);
+      }
+    }
+    return svc || null;
+  }
+
   function getSelection() {
     const scope = document.body.getAttribute("data-scope") || "contacts";
     try {
-      const svc = window.SelectionService || window.Selection;
+      const svc = resolveSelectionService();
       if (svc) {
         let ids;
         let type = scope;


### PR DESCRIPTION
## Summary
- align the contacts merge orchestrator with the shared `selection:change` event name after merges
- add an action bar safety patch that keeps merge enablement synchronized and delegates merge clicks to the correct orchestrator
- register the new safety patch in the boot manifest so it loads with the rest of the defensive patches
- correct the safety patch to resolve the shared `SelectionService` before reading selections so merge clicks execute when two items are selected

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e56cd867f08326a1d12c210a111158