### PR TITLE
Address Codex feedback: fix launcher auto-exit debug guard

### DIFF
--- a/tools/Start-CRM.ps1
+++ b/tools/Start-CRM.ps1
@@ -253,8 +253,14 @@ try {
     Write-Log "[EXIT] success."
     try {
       # If we reached here, server is up and browser launched; exit this host so the console closes.
-      # Respect the explicit CRM_DEBUG escape hatch so developers can keep the host open when needed.
-      if (-not $env:CRM_DEBUG) {
+      # Respect the explicit CRM_DEBUG escape hatch and avoid exiting when a debugging preference is active.
+      $shouldAutoExit = -not $env:CRM_DEBUG
+
+      if ($DebugPreference -and $DebugPreference -notin @('SilentlyContinue', 'Continue')) {
+        $shouldAutoExit = $false
+      }
+
+      if ($shouldAutoExit) {
         Start-Sleep -Seconds 1
         $host.SetShouldExit(0)
         exit


### PR DESCRIPTION
## Summary
- ensure the launcher auto-exits when CRM_DEBUG is unset and no debugging preference is active
- treat DebugPreference values other than SilentlyContinue/Continue as debugging to keep the host open

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e571bd77948326898358c0c4c1bc8a