### PR TITLE
Follow-up: ensure removed profile photos stay cleared

### DIFF
--- a/crm-app/js/settings_forms.js
+++ b/crm-app/js/settings_forms.js
@@ -445,10 +445,15 @@ function __textFallback__(k){ try { return (STR && STR[k]) || (__STR_FALLBACK__[
     profileState.phone = mergedProfile && mergedProfile.phone ? mergedProfile.phone : '';
     const mergedPhoto = typeof mergedProfile.photoDataUrl === 'string' ? mergedProfile.photoDataUrl : '';
     const persistedPhoto = SettingsPhoto.loadDataUrl();
-    profileState.photoDataUrl = persistedPhoto || mergedPhoto || '';
+    const removalPending = typeof SettingsPhoto.wasExplicitlyCleared === 'function' && SettingsPhoto.wasExplicitlyCleared();
+    profileState.photoDataUrl = removalPending ? '' : (persistedPhoto || mergedPhoto || '');
     const storedSignature = readSignatureLocal();
     profileState.signature = storedSignature || (mergedProfile && mergedProfile.signature ? mergedProfile.signature : '');
-    SettingsPhoto.saveDataUrl(profileState.photoDataUrl, { broadcast: false });
+    if (removalPending) {
+      SettingsPhoto.saveDataUrl('', { broadcast: false, notifyApp: false });
+    } else if (profileState.photoDataUrl !== persistedPhoto) {
+      SettingsPhoto.saveDataUrl(profileState.photoDataUrl, { broadcast: false });
+    }
     if(nameInput) nameInput.value = profileState.name;
     if(emailInput) emailInput.value = profileState.email;
     if(phoneInput) phoneInput.value = profileState.phone;

--- a/crm-app/js/settings_profile_photo.js
+++ b/crm-app/js/settings_profile_photo.js
@@ -1,5 +1,6 @@
 const PROFILE_KEY = "profile:v1";
 const PHOTO_KEY = "profile.photoDataUrl";
+const PHOTO_CLEARED_KEY = "profile.photoCleared";
 
 function normalizeDataUrl(dataUrl) {
   return typeof dataUrl === "string" ? dataUrl : "";
@@ -98,6 +99,24 @@ function writeFallbackPhoto(dataUrl) {
   } catch (_) {}
 }
 
+function writeClearedFlag(dataUrl) {
+  try {
+    if (dataUrl) {
+      localStorage.removeItem(PHOTO_CLEARED_KEY);
+    } else {
+      localStorage.setItem(PHOTO_CLEARED_KEY, "1");
+    }
+  } catch (_) {}
+}
+
+function readClearedFlag() {
+  try {
+    return localStorage.getItem(PHOTO_CLEARED_KEY) === "1";
+  } catch (_) {
+    return false;
+  }
+}
+
 function dispatchStoredEvent(dataUrl, broadcastOptions) {
   if (typeof document === "undefined") return;
   try {
@@ -171,6 +190,7 @@ function saveDataUrl(dataUrl, options = {}) {
   updateLocalProfile(normalized);
   updateGlobalProfile(normalized);
   writeFallbackPhoto(normalized);
+  writeClearedFlag(normalized);
 
   if (changed && options.broadcast !== false) {
     dispatchStoredEvent(normalized, { notifyApp: options.notifyApp !== false });
@@ -181,6 +201,7 @@ function saveDataUrl(dataUrl, options = {}) {
 export const SettingsPhoto = {
   saveDataUrl,
   loadDataUrl,
+  wasExplicitlyCleared: readClearedFlag,
 };
 
 export default SettingsPhoto;


### PR DESCRIPTION
## Summary
- track when the profile photo has been explicitly cleared so hydrations honor the removal
- avoid rewriting the stored photo from hydration when a removal is pending, keeping the UI and header empty until save

## Testing
- not run (environment missing browser-only modules during Vitest run)


------
https://chatgpt.com/codex/tasks/task_e_68e571dbf56083268ee72e9e007ee3b8