### PR TITLE
Fix selection type when legacy get returns array

### DIFF
--- a/crm-app/js/patch_2025-10-08_actionbar_harden.js
+++ b/crm-app/js/patch_2025-10-08_actionbar_harden.js
@@ -33,6 +33,11 @@
             const type = payload.type || scope;
             return { ids, type };
           }
+          if (Array.isArray(payload)) {
+            const ids = payload.map(String);
+            const type = typeof svc.type === "string" && svc.type ? svc.type : scope;
+            return { ids, type };
+          }
         }
         if (typeof svc.getIds === "function") {
           const ids = normalizeIds(svc.getIds());


### PR DESCRIPTION
## Summary
- honor legacy selection services that return a bare array from get(scope)
- default merge type from the service's declared scope when available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e580af06008326b7f728208183f7c8