### PR TITLE
Fix legacy SelectionService array type propagation

### DIFF
--- a/crm-app/js/patch_2025-10-07_actionbar_wiring_safety.js
+++ b/crm-app/js/patch_2025-10-07_actionbar_wiring_safety.js
@@ -32,6 +32,9 @@
             payloadType = type;
           } else if (Array.isArray(payload)) {
             ids = payload.slice();
+            if (typeof svc.type === "string" && svc.type) {
+              payloadType = svc.type;
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
- ensure legacy SelectionService array payloads propagate the service type for downstream routing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5807dc4e88326b8a9d34bd4565051