### PR TITLE
Fix legacy selection type detection for legacy get array payload

### DIFF
--- a/crm-app/js/patch_2025-10-07_actionbar_wiring_safety.js
+++ b/crm-app/js/patch_2025-10-07_actionbar_wiring_safety.js
@@ -32,6 +32,9 @@
             payloadType = type;
           } else if (Array.isArray(payload)) {
             ids = payload.slice();
+            if (typeof svc.type === "string" && svc.type) {
+              type = svc.type;
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
- ensure SelectionService-derived type is preserved when legacy get() returns an array of ids

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e582eb014c8326b87f21bcca2dafc2