### PR TITLE
Follow-up: Preserve service type for legacy selection arrays

### DIFF
--- a/crm-app/js/patch_2025-10-07_actionbar_wiring_safety.js
+++ b/crm-app/js/patch_2025-10-07_actionbar_wiring_safety.js
@@ -13,6 +13,7 @@
         let type = scope;
         let fromModernSource = false;
         let payloadType;
+        const svcType = typeof svc.type === "string" && svc.type ? svc.type : undefined;
 
         if (typeof svc.getIds === "function") {
           const result = svc.getIds();
@@ -29,20 +30,21 @@
           if (Array.isArray(payload?.ids)) {
             ids = payload.ids.slice();
             if (typeof payload.type === "string" && payload.type) type = payload.type;
-            payloadType = type;
+            payloadType = typeof payload.type === "string" && payload.type ? payload.type : svcType;
+            if (!payload.type && svcType) type = svcType;
           } else if (Array.isArray(payload)) {
             ids = payload.slice();
-            if (typeof svc.type === "string" && svc.type) {
-              payloadType = svc.type;
-              type = svc.type;
+            if (svcType) {
+              payloadType = svcType;
+              type = svcType;
             }
           }
         }
 
         if (Array.isArray(ids)) {
-          if (typeof svc.type === "string" && svc.type) {
-            if (fromModernSource || (payloadType && svc.type === payloadType)) {
-              type = svc.type;
+          if (svcType) {
+            if (fromModernSource || (payloadType && svcType === payloadType) || !payloadType) {
+              type = svcType;
             }
           }
           return { ids, type };


### PR DESCRIPTION
## Summary
- normalize access to `svc.type` once and reuse when legacy selection sources provide ids
- ensure legacy `get()` array payloads adopt the service-reported type so merge routing stays correct
- fall back to the service type when payload metadata is missing to avoid regressions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e583f208b88326ae5766b2e093ecde