### PR TITLE
Fix selection type fallback for action bar merge follow-up

### DIFF
--- a/crm-app/js/patch_2025-10-07_actionbar_wiring_safety.js
+++ b/crm-app/js/patch_2025-10-07_actionbar_wiring_safety.js
@@ -26,6 +26,7 @@
       if (svc) {
         let ids;
         let type = scope;
+        let typeFromPayload = false;
 
         const assignFromPayload = (payload) => {
           if (!payload) return false;
@@ -35,13 +36,19 @@
           }
           if (Array.isArray(payload.ids)) {
             ids = payload.ids.slice();
-            if (typeof payload.type === "string" && payload.type) type = payload.type;
+            if (typeof payload.type === "string" && payload.type) {
+              type = payload.type;
+              typeFromPayload = true;
+            }
             return true;
           }
           if (Array.isArray(payload.selection?.ids)) {
             ids = payload.selection.ids.slice();
             const payloadType = payload.selection.type || payload.type;
-            if (typeof payloadType === "string" && payloadType) type = payloadType;
+            if (typeof payloadType === "string" && payloadType) {
+              type = payloadType;
+              typeFromPayload = true;
+            }
             return true;
           }
           return false;
@@ -68,7 +75,9 @@
         }
 
         if (Array.isArray(ids)) {
-          if (typeof svc.type === "string" && svc.type) type = svc.type;
+          if (!typeFromPayload && typeof svc.type === "string" && svc.type) {
+            type = svc.type;
+          }
           return { ids, type };
         }
       }


### PR DESCRIPTION
## Summary
- track whether the selection payload specified a type before falling back to the service metadata
- only use the service type when no payload-derived type is available to avoid misrouting merges

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e583f3b3e883268bb667db630f76c2