### PR TITLE
Add selection forward guard to prevent loops

### DIFF
--- a/crm-app/js/patch_2025-10-08_selection_guard.js
+++ b/crm-app/js/patch_2025-10-08_selection_guard.js
@@ -104,13 +104,19 @@
   document.addEventListener("click", handleClick, true);
 
   function forwardToWindow(ev) {
-    const detail = Object.assign({}, ev.detail || {}, { [FORWARD_FLAG]: "doc" });
-    try { window.dispatchEvent(new CustomEvent("selection:change", { detail })); } catch {}
+    const forwarded = ev?.detail?.[FORWARD_FLAG];
+    if (!forwarded) {
+      const detail = { ...(ev.detail || {}), [FORWARD_FLAG]: "doc" };
+      try { window.dispatchEvent(new CustomEvent("selection:change", { detail })); } catch {}
+    }
     syncChecks();
   }
   function forwardToDocument(ev) {
-    const detail = Object.assign({}, ev.detail || {}, { [FORWARD_FLAG]: "win" });
-    try { document.dispatchEvent(new CustomEvent("selection:changed", { detail })); } catch {}
+    const forwarded = ev?.detail?.[FORWARD_FLAG];
+    if (!forwarded) {
+      const detail = { ...(ev.detail || {}), [FORWARD_FLAG]: "win" };
+      try { document.dispatchEvent(new CustomEvent("selection:changed", { detail })); } catch {}
+    }
     syncChecks();
   }
 


### PR DESCRIPTION
## Summary
- skip redispatching selection events that already carry the guard flag
- continue syncing check states while preventing window/document forwarding loops

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5fa063c388326b1b879039408991d