### PR TITLE
Fix fallback selection get to return actual type

### DIFF
--- a/crm-app/js/patch_2025-10-08_selection_guard.js
+++ b/crm-app/js/patch_2025-10-08_selection_guard.js
@@ -35,7 +35,9 @@
   function createFallbackSelection() {
     const api = {
       get(scope) {
-        const type = normalizeType(scope || fallbackState.type);
+        const actualType = fallbackState.type;
+        const requestedType = scope ? normalizeType(scope) : undefined;
+        const type = requestedType && requestedType === actualType ? requestedType : actualType;
         const ids = cloneFallbackIds();
         return { ids, type };
       },


### PR DESCRIPTION
## Summary
- ensure the fallback selection service reports the actual selection type when scope differs from the request
- preserve existing behavior when the requested scope matches the active selection

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6133c28f08326a810a096ae888df8